### PR TITLE
examples: add SPH rain mode (switchable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ This repository contains small code snippets for the Genesis physics simulator.
   Notes:
   - Windows console may not render Unicode emojis/box characters; the example sets `theme="dumb"` and supports `--quiet` to reduce banners.
   - SPH mode is more physically/visually detailed but heavier than the light mode. Start with defaults before increasing particle rate.
+### Presets
+You can quickly try typical scenarios with `-p/--preset`:
+- `calm` (light): light wind, gentle rain force, mild drag
+- `breezy` (light): medium wind, moderate rain force, moderate drag
+- `storm` (light): strong wind, heavy rain force, stronger drag
+- `drizzle-sph` (sph): sparse particle rain, slower speed, less frequent emission
+- `downpour-sph` (sph): small droplets, fast speed, frequent emission
+
+Examples:
+- `python examples\drone_wind_sim.py --preset calm --steps 300 --quiet`
+- `python examples\drone_wind_sim.py --preset drizzle-sph --steps 300 --quiet`

--- a/README.md
+++ b/README.md
@@ -3,5 +3,23 @@
 This repository contains small code snippets for the Genesis physics simulator.
 
 ## Examples
-- `examples/drone_wind_sim.py`: Simulates a quadrotor affected by a constant wind
-  using the Genesis API.
+- `examples/drone_wind_sim.py`: Quadrotor (CF2X) under wind + rain, using the upstream Genesis API.
+
+  Modes and usage:
+  - Light (default): constant wind + downward rain force (+ optional linear drag)
+  - SPH: particle-based rain (SPH Liquid + emitter)
+
+  Commands (PowerShell):
+  - `python examples\drone_wind_sim.py`  # light mode
+  - `python examples\drone_wind_sim.py --mode sph`  # SPH rain
+  - Options:
+    - `--steps N` (default 1000)
+    - `--wind WX WY WZ` (default `2 0 0`)
+    - `--rain-down Fz` (default `0.8`), `--drag C` (default `0.0`)
+    - `--sph-size S` (default `0.03`), `--sph-speed V` (default `4.0`)
+    - `--sph-pos PX PY PZ` (default `0 0 2.5`), `--sph-interval K` (default `1`)
+    - `-v/--vis` to show the viewer, `--quiet` to reduce logging noise
+
+  Notes:
+  - Windows console may not render Unicode emojis/box characters; the example sets `theme="dumb"` and supports `--quiet` to reduce banners.
+  - SPH mode is more physically/visually detailed but heavier than the light mode. Start with defaults before increasing particle rate.

--- a/examples/drone_wind_sim.py
+++ b/examples/drone_wind_sim.py
@@ -75,7 +75,65 @@ def main() -> None:
     )
     parser.add_argument("--sph-interval", type=int, default=1, help="Emit every k steps (>=1)")
 
+    # Presets (applies after parsing and may override provided defaults)
+    parser.add_argument(
+        "-p",
+        "--preset",
+        choices=[
+            "calm",
+            "breezy",
+            "storm",
+            "drizzle-sph",
+            "downpour-sph",
+        ],
+        help="Convenience presets for typical conditions",
+    )
+
     args = parser.parse_args()
+
+    # Apply presets by updating parsed args as baseline (flags still can override by re-running)
+    if args.preset:
+        presets = {
+            # Light mode presets
+            "calm": {
+                "mode": "light",
+                "wind": (0.5, 0.0, 0.0),
+                "rain_down": 0.2,
+                "drag": 0.05,
+            },
+            "breezy": {
+                "mode": "light",
+                "wind": (2.0, 0.3, 0.0),
+                "rain_down": 0.6,
+                "drag": 0.12,
+            },
+            "storm": {
+                "mode": "light",
+                "wind": (8.0, 1.0, 0.0),
+                "rain_down": 2.0,
+                "drag": 0.3,
+            },
+            # SPH mode presets
+            "drizzle-sph": {
+                "mode": "sph",
+                "wind": (1.0, 0.0, 0.0),
+                "sph_size": 0.035,
+                "sph_speed": 3.0,
+                "sph_interval": 4,
+                "sph_pos": (0.0, 0.0, 2.5),
+            },
+            "downpour-sph": {
+                "mode": "sph",
+                "wind": (3.0, 0.5, 0.0),
+                "sph_size": 0.02,
+                "sph_speed": 6.0,
+                "sph_interval": 1,
+                "sph_pos": (0.0, 0.0, 2.5),
+            },
+        }
+        cfg = presets[args.preset]
+        for k, v in cfg.items():
+            setattr(args, k, v)
     # Initialize Genesis; default to CPU backend on Windows
     # Use a simple theme to avoid Unicode box characters on some consoles
     init_kwargs = dict(backend=gs.cpu, theme="dumb")


### PR DESCRIPTION
Add SPH rain mode and a `--mode {light,sph}` switch, plus runtime CLI controls and README docs.

- Light mode: constant wind + downward rain force, optional linear drag `-c*v`
- SPH mode: SPH Liquid + emitter added pre-build; emit droplets at a tunable interval
- CLI options:
  - General: `--steps`, `--wind WX WY WZ`, `--quiet`, `-v/--vis`
  - Light: `--rain-down`, `--drag`
  - SPH: `--sph-size`, `--sph-speed`, `--sph-pos PX PY PZ`, `--sph-interval`
- README updated with usage examples and notes

Notes:
- Windows consoles may not render emojis/box-drawing; example uses `theme="dumb"` and `--quiet` to reduce banners.
- SPH is heavier than light mode; start with defaults to gauge performance.